### PR TITLE
Allow default import syntax from TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ const util = require('util');
 
 module.exports = Verifier;
 
+// Allow default import syntax from TypeScript
+module.exports.default = Verifier;
+
 function Verifier(options) {
   this.options = options || {};
 }


### PR DESCRIPTION
### Description
Currently, importing the library from TypeScript doesn't work as advertised. According to the types file, it should be imported like this:

```
import googleVerify from "google-play-billing-validator";
new googleVerify({ email: "foo", key: "bar" });
```

However, while this compiles, it causes a runtime error: `TypeError: google_play_billing_validator_1.default is not a constructor`

It's currently possible to make this work with TypeScript, but it forces the user to force a cast, which defeats the purpose of using types:

```
import * as googleVerify from "google-play-billing-validator";
// needs "as any", or it won't compile
new (googleVerify as any)({ email: "foo", key: "bar" });
```

Adding the default import syntax would allow the code from the first example to work as advertised, and is also a typical solution (e.g., off the top of my mind, [Axios does this](https://github.com/axios/axios/blob/fe52a611efe756328a93709bbf5265756275d70d/dist/axios.js#L116)).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
