### PR TITLE
Support for the `subscriptionsv2` endpoint, that works without `productId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ promiseData.then(function(response) {
 })
 ```
 
+##### Validate Subscription v2
+
+Subscription can be validated with the v2 API, that does not require `productId`.
+Second parameter to `verifySub` (boolean) should be set to `true`.
+
+```javascript
+let receipt = {
+    packageName: "your app package name",
+    purchaseToken: "purchase token"
+};
+let promiseData = verifier.verifySub(receipt, true)
+```
+
 ##### Acknowledge Purchase / Subscription
 To acknowledge a purchase or a subscription, simple add `developerPayload: <String>` to the `receipt` object
 eg:

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export interface InAppPurchasePayloadResponse {
 
 export interface IVerifier {
   verifyINAPP(receipt: Receipt): Promise<any>;
-  verifySub(receipt: Receipt): Promise<any>;
+  verifySub(receipt: Receipt, v2?: boolean): Promise<any>;
 }
 declare const Verifier: {
   new (options: Options): IVerifier;

--- a/index.js
+++ b/index.js
@@ -29,12 +29,14 @@ Verifier.prototype.verifyINAPP = function (receipt) {
   return this.verify(finalUrl)
 };
 
-Verifier.prototype.verifySub = function (receipt) {
+Verifier.prototype.verifySub = function (receipt, v2 = false) {
   this.options.method = 'get';
   this.options.body = "";
   this.options.json = false;
   
-  let urlPattern = "https://www.googleapis.com/androidpublisher/v3/applications/%s/purchases/subscriptions/%s/tokens/%s";
+  let urlPattern = v2
+    ? "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/%s/purchases/subscriptionsv2/tokens/%s"
+    : "https://www.googleapis.com/androidpublisher/v3/applications/%s/purchases/subscriptions/%s/tokens/%s";
   if ("developerPayload" in receipt) {
     urlPattern += ":acknowledge";
     this.options.body = {
@@ -43,7 +45,9 @@ Verifier.prototype.verifySub = function (receipt) {
     this.options.method = 'post';
     this.options.json = true;
   }
-  let finalUrl = util.format(urlPattern, encodeURIComponent(receipt.packageName), encodeURIComponent(receipt.productId), encodeURIComponent(receipt.purchaseToken));
+  let finalUrl = v2
+    ? util.format(urlPattern, encodeURIComponent(receipt.packageName), encodeURIComponent(receipt.purchaseToken))
+    : util.format(urlPattern, encodeURIComponent(receipt.packageName), encodeURIComponent(receipt.productId), encodeURIComponent(receipt.purchaseToken));
   
   return this.verify(finalUrl)
 };


### PR DESCRIPTION
### Description
Support for the `subscriptionsv2` endpoint, that works without `productId`.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
